### PR TITLE
Add check-version to branch workflow

### DIFF
--- a/.github/workflows/react-lint-testing.yml
+++ b/.github/workflows/react-lint-testing.yml
@@ -35,3 +35,21 @@ jobs:
           echo "Tags: $TAGS"
         env:
           TAGS: ${{ github.event.inputs.tags }}
+          
+  check-version:
+    name: 'Check version'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: git fetch --depth=1 --tags origin
+      - name: Install yq
+        run: sudo snap install yq
+      - name: Check Build Version
+        id: get_version
+        run: ./scripts/check-version.sh
+        shell: bash
+      - name: Error if version is not increased
+        shell: bash
+        run: |
+          exit $([[ "${{steps.get_version.outputs.IS_NEW_VERSION}}" = "true" ]] && echo 0 || echo 1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-authority",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-authority",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-authority",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Front-end for Veritable authority",
   "author": "Digital Catapult (https://www.digicatapult.org.uk/)",
   "license": "Apache-2.0",


### PR DESCRIPTION
Add `check-version` to the branch workflow so it reminds us to bump versions before merging.